### PR TITLE
Dynamo API endpoint improvements

### DIFF
--- a/MonitoringKit/Monitoring_X8/src/Monitoring_X8.cpp
+++ b/MonitoringKit/Monitoring_X8/src/Monitoring_X8.cpp
@@ -362,7 +362,7 @@ void publishSensorData(SensorData arr[]) {
         JsonObject obj1 = jsonArr.add<JsonObject>();
         obj1["deviceId"] = arr[i].device;
         obj1["sensor"] = arr[i].sensor;
-        obj1["timestamp"] = arr[i].timestamp;
+        obj1["recordedTimestamp"] = arr[i].timestamp;
         obj1["tiaq"] = arr[i].tiaq;
         obj1["tiaqAccuracy"] = arr[i].tiaqAccuracy;
         obj1["ttemperature"] = arr[i].ttemperature;

--- a/MonitoringKit/Monitoring_X8/src/Monitoring_X8.cpp
+++ b/MonitoringKit/Monitoring_X8/src/Monitoring_X8.cpp
@@ -360,7 +360,7 @@ void publishSensorData(SensorData arr[]) {
 
     for (int i=0; i<SENSOR_DATA_BUFFER_LENGTH; i++){
         JsonObject obj1 = jsonArr.add<JsonObject>();
-        obj1["device"] = arr[i].device;
+        obj1["deviceId"] = arr[i].device;
         obj1["sensor"] = arr[i].sensor;
         obj1["timestamp"] = arr[i].timestamp;
         obj1["tiaq"] = arr[i].tiaq;

--- a/air-quality-sst/README.md
+++ b/air-quality-sst/README.md
@@ -8,7 +8,8 @@ Run `npm run dev` to test lambda and other services locally
 
 ## Deploying
 
-Run `npx sst deploy --stage prod` to deploy  
+Run `npm run deployStage` to deploy to stage  
+Run `npm run deployProd` to deploy to prod  
 
 ## Documentation
 

--- a/air-quality-sst/package.json
+++ b/air-quality-sst/package.json
@@ -7,6 +7,8 @@
     "dev": "sst dev",
     "build": "sst build",
     "deploy": "sst deploy",
+    "deployStage": "sst deploy --stage stage",
+    "deployProd": "sst deploy --stage prod",
     "remove": "sst remove",
     "console": "sst console",
     "typecheck": "tsc --noEmit"

--- a/air-quality-sst/packages/functions/src/sensorData.ts
+++ b/air-quality-sst/packages/functions/src/sensorData.ts
@@ -13,6 +13,7 @@ export const createData: APIGatewayProxyHandlerV2 = async (event) => {
 
   if (!data || typeof(data.deviceId) !== "string" || typeof(data.recordedTimestamp) !== "number"){
     return {
+      headers: {"content-type": "application/json"},
       statusCode: 400,
       body: JSON.stringify({message: 'Invalid Parameter'}),
     }
@@ -26,6 +27,7 @@ export const createData: APIGatewayProxyHandlerV2 = async (event) => {
   await dynamoDb.put(params).promise();
 
   return {
+    headers: {"content-type": "application/json"},
     statusCode: 200,
     body: JSON.stringify(params.Item),
   };
@@ -44,6 +46,7 @@ export const getData: APIGatewayProxyHandlerV2 = ApiHandler(async (event) => {
 
   if (!deviceId){
     return{
+      headers: {"content-type": "application/json"},
       statusCode: 400,
       body: JSON.stringify({message: 'deviceId is required'}),
     }
@@ -54,6 +57,7 @@ export const getData: APIGatewayProxyHandlerV2 = ApiHandler(async (event) => {
      recordedTimestampNumber = Number(recordedTimestamp);
     if (isNaN(recordedTimestampNumber)){
       return {
+        headers: {"content-type": "application/json"},
         statusCode: 400,
         body: JSON.stringify({message: 'recordedTimestamp must be a number'}),
       } 
@@ -78,6 +82,7 @@ export const getData: APIGatewayProxyHandlerV2 = ApiHandler(async (event) => {
   const results = await dynamoDb.query(params).promise();
 
   return {
+    headers: {"content-type": "application/json"},
     statusCode: 200,
     body: JSON.stringify(results.Items),
   };

--- a/air-quality-sst/packages/functions/src/sensorData.ts
+++ b/air-quality-sst/packages/functions/src/sensorData.ts
@@ -1,13 +1,26 @@
-// packages/functions/src/create.ts
-import * as uuid from "uuid";
 import AWS from "aws-sdk";
 import { Table } from "sst/node/table";
 import { APIGatewayProxyHandlerV2 } from "aws-lambda";
+import { ApiHandler, usePathParams, useQueryParams } from "sst/node/api";
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient();
 
+/**
+ * Put a sensorData item into the database
+ */
 export const createData: APIGatewayProxyHandlerV2 = async (event) => {
   const data = JSON.parse(event?.body || "");
+
+  if (!data || typeof(data.deviceId) !== "string" || typeof(data.recordedTimestamp) !== "number" || typeof(data.sensorNumber) !== "number"){
+    return {
+      statusCode: 400,
+      body: JSON.stringify({message: 'Invalid Parameter'}),
+    }
+  }
+
+  if (!data.lablel){
+    data.label = "";
+  }
 
   const params = {
     TableName: Table.SensorData.tableName,
@@ -23,14 +36,52 @@ export const createData: APIGatewayProxyHandlerV2 = async (event) => {
 };
 
 
-export const getData: APIGatewayProxyHandlerV2 = async (event) => {
+/**
+ * Get sensor data from a given device.
+ * Only returns records newer than the recordedTimestamp if it is provided.
+ * The deviceId is a path param and the recordedTimestamp is a query param.
+ */
+export const getData: APIGatewayProxyHandlerV2 = ApiHandler(async (event) => {
+  const { deviceId } = usePathParams();
+  const { recordedTimestamp } = useQueryParams();
+
+
+  if (!deviceId){
+    return{
+      statusCode: 400,
+      body: JSON.stringify({message: 'deviceId is required'}),
+    }
+  }
+
+  const recordedTimestampNumber = Number(recordedTimestamp);
+  if (isNaN(recordedTimestampNumber)){
+    return {
+      statusCode: 400,
+      body: JSON.stringify({message: 'recordedTimestamp must be a number'}),
+    } 
+  }
+
+  const KeyConditionExpression = !!recordedTimestamp ? 'deviceId = :hkey and recordedTimestamp >= :skey' : 'deviceId = :hkey'
+  const ExpressionAttributeValues = {
+    ':hkey': deviceId,
+    ':skey': recordedTimestampNumber
+  }
+
+  console.log(KeyConditionExpression);
+  console.log(ExpressionAttributeValues);
+  
+
+  // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#query-property
   const params = {
     TableName: Table.SensorData.tableName,
+    KeyConditionExpression,
+    ExpressionAttributeValues,
   };
-  const results = await dynamoDb.scan(params).promise();
+
+  const results = await dynamoDb.query(params).promise();
 
   return {
     statusCode: 200,
     body: JSON.stringify(results.Items),
   };
-}
+});

--- a/air-quality-sst/packages/functions/src/sensorData.ts
+++ b/air-quality-sst/packages/functions/src/sensorData.ts
@@ -17,7 +17,7 @@ export const createData: APIGatewayProxyHandlerV2 = async (event) => {
       body: JSON.stringify({message: 'Invalid Parameter'}),
     }
   }
-  
+
   const params = {
     TableName: Table.SensorData.tableName,
     Item: data,
@@ -49,23 +49,24 @@ export const getData: APIGatewayProxyHandlerV2 = ApiHandler(async (event) => {
     }
   }
 
-  const recordedTimestampNumber = Number(recordedTimestamp);
-  if (isNaN(recordedTimestampNumber)){
-    return {
-      statusCode: 400,
-      body: JSON.stringify({message: 'recordedTimestamp must be a number'}),
-    } 
+  let recordedTimestampNumber = null;
+  if (recordedTimestamp){
+     recordedTimestampNumber = Number(recordedTimestamp);
+    if (isNaN(recordedTimestampNumber)){
+      return {
+        statusCode: 400,
+        body: JSON.stringify({message: 'recordedTimestamp must be a number'}),
+      } 
+    }
   }
+  
 
   const KeyConditionExpression = !!recordedTimestamp ? 'deviceId = :hkey and recordedTimestamp >= :skey' : 'deviceId = :hkey'
   const ExpressionAttributeValues = {
     ':hkey': deviceId,
-    ':skey': recordedTimestampNumber
+    ...(recordedTimestampNumber && {':skey': recordedTimestampNumber})
   }
 
-  console.log(KeyConditionExpression);
-  console.log(ExpressionAttributeValues);
-  
 
   // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#query-property
   const params = {

--- a/air-quality-sst/packages/functions/src/sensorData.ts
+++ b/air-quality-sst/packages/functions/src/sensorData.ts
@@ -11,17 +11,13 @@ const dynamoDb = new AWS.DynamoDB.DocumentClient();
 export const createData: APIGatewayProxyHandlerV2 = async (event) => {
   const data = JSON.parse(event?.body || "");
 
-  if (!data || typeof(data.deviceId) !== "string" || typeof(data.recordedTimestamp) !== "number" || typeof(data.sensorNumber) !== "number"){
+  if (!data || typeof(data.deviceId) !== "string" || typeof(data.recordedTimestamp) !== "number"){
     return {
       statusCode: 400,
       body: JSON.stringify({message: 'Invalid Parameter'}),
     }
   }
-
-  if (!data.lablel){
-    data.label = "";
-  }
-
+  
   const params = {
     TableName: Table.SensorData.tableName,
     Item: data,

--- a/air-quality-sst/packages/web/index.html
+++ b/air-quality-sst/packages/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Air Quality Monitoring</title>
   </head>
   <body>
     <div id="root"></div>

--- a/air-quality-sst/sst.config.ts
+++ b/air-quality-sst/sst.config.ts
@@ -16,5 +16,9 @@ export default {
     app.stack(ApiStack);
     app.stack(WebStack);
     app.stack(AuthStack);
+    // Remove all resources when non-prod stages are removed
+    if (app.stage !== "prod") {
+      app.setDefaultRemovalPolicy("destroy");
+    }
   },
 } satisfies SSTConfig;

--- a/air-quality-sst/stacks/ApiStack.ts
+++ b/air-quality-sst/stacks/ApiStack.ts
@@ -15,7 +15,7 @@ export function ApiStack({ stack, app }: StackContext) {
     routes: {
       "GET /": "packages/functions/src/lambda.handler",
       "GET /session": "packages/functions/src/session.handler",
-      "GET /api/sensorData": "packages/functions/src/sensorData.getData",
+      "GET /api/sensorData/{deviceId}": "packages/functions/src/sensorData.getData",
       "POST /api/sensorData": "packages/functions/src/sensorData.createData",
     },
   });

--- a/air-quality-sst/stacks/StorageStack.ts
+++ b/air-quality-sst/stacks/StorageStack.ts
@@ -5,8 +5,6 @@ export function StorageStack({ stack, app }: StackContext) {
     fields: {
         deviceId: "string",
         recordedTimestamp: "number",
-        lablel: "string",
-        sensorNumber: "number",
     },
     primaryIndex: { partitionKey: "deviceId", sortKey: "recordedTimestamp" },
   });

--- a/air-quality-sst/stacks/StorageStack.ts
+++ b/air-quality-sst/stacks/StorageStack.ts
@@ -4,11 +4,11 @@ export function StorageStack({ stack, app }: StackContext) {
   const sensorDataTable = new Table(stack, "SensorData", {
     fields: {
         deviceId: "string",
-        timeStamp: "number",
+        recordedTimestamp: "number",
         lablel: "string",
         sensorNumber: "number",
     },
-    primaryIndex: { partitionKey: "deviceId", sortKey: "timeStamp" },
+    primaryIndex: { partitionKey: "deviceId", sortKey: "recordedTimestamp" },
   });
   const usersTable = new Table(stack, "Users", {
     fields: {


### PR DESCRIPTION
- improve error handling for dynamo API routes
- make the getData endpoint take in a deviceId and an optional recorded timestamp
- change sensorData DB syntax to remove optional fields
- change timestamp to recordedTimestamp since it is a DynamoDB reserved word
- change user creation from PUT operation to UPDATE operation to only overwrite the parts that we want